### PR TITLE
Fix documentation for install location

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -29,13 +29,13 @@ gem list to actually be empty? Me too. Now you can.
   rdoc (4.0.0)
   test-unit (2.0.0.0)
 
-  $ gem install rubygems-cleanroom
+  $ gem install -i xxx rubygems-cleanroom
   ...
   $ GEM_HOME=xxx GEM_PATH=xxx gem list
 
   *** LOCAL GEMS ***
-
-  $ 
+  
+  rubygems-cleanroom (1.0.0)
 
 == REQUIREMENTS:
 


### PR DESCRIPTION
`rubygems-cleanroom` currently needs to be installed in an
empty repo that is on the gem path for it to work.

Fixes #1
